### PR TITLE
Added -dump_pip <output_file_pip.txt> option

### DIFF
--- a/torus_src/classdef.h
+++ b/torus_src/classdef.h
@@ -163,6 +163,8 @@ class controller {
   void find_eGene(double thresh=0.05);
   void estimate();
   void dump_prior(char *path);
+  void dump_pip(char *file);
+
 
  private:
   double eval_likelihood(double x, int index);

--- a/torus_src/controller.cc
+++ b/torus_src/controller.cc
@@ -1092,6 +1092,26 @@ void controller::dump_prior(char *prior_path){
     fclose(fd);
   }
 }
+
+
+void controller::dump_pip(char *file){
+  if(!finish_em){
+    run_EM();
+    finish_em = 1;
+  }
+  fprintf(stderr,"Output pip file: %s ...\n",file);
+  FILE *fd = fopen(file, "w");
+  for( int i=0; i<locVec.size();i++){
+    string gname = locVec[i].id;
+    for(int j=0;j<locVec[i].snpVec.size();j++){
+      int index = locVec[i].snpVec[j].index;
+      string name = locVec[i].snpVec[j].id;
+      fprintf(fd, "%s\t%s\t%9.4e\t%9.4e\t%9.4e\n",name.c_str(), gname.c_str(), gsl_vector_get(prior_vec, index), gsl_vector_get(pip_vec, index), locVec[i].fdr);
+    }
+  }
+  fclose(fd);
+}
+
 						
     
 

--- a/torus_src/main.cc
+++ b/torus_src/main.cc
@@ -27,6 +27,7 @@ int main(int argc, char **argv){
   char smap_file[128];
   char annot_file[128];
   char prior_dir[128];
+  char output_pip[128];
 
   int csize = -1;
   int gsize = -1;
@@ -52,7 +53,7 @@ int main(int argc, char **argv){
   memset(annot_file,0,128);
   memset(init_file,0,128);
   memset(prior_dir,0,128);
-  
+  memset(output_pip,0,128);
 
   int force_logistic = 0;
   int prob_annot = 0;
@@ -159,6 +160,11 @@ int main(int argc, char **argv){
       continue;
     }
 
+    if(strcmp(argv[i], "-dump_pip")==0){
+      strcpy(output_pip, argv[++i]);
+      continue;
+    }
+
 
     if(strcmp(argv[i], "-h")==0 || strcmp(argv[i], "-help")==0 ){
       show_banner();
@@ -245,6 +251,10 @@ int main(int argc, char **argv){
   }
   if(strlen(prior_dir)>0){
     con.dump_prior(prior_dir);
+  }
+  if(strlen(output_pip)>0){
+    fprintf(stderr,"#-dump_pip output_pip file: %s \n",output_pip);
+    con.dump_pip(output_pip);
   }
 }
 


### PR DESCRIPTION
- The `-dump_pip file` option, outputs a file with the following format:

```
SNP      GeneID Prior      PIP      eGENE_FDR
rs2072449       ENSG00000171860 6.7521e-04      9.9036e-01      8.2579e-25
...
```

The first column represents the SNP name and 2nd column represent the name of a gene/locus as it is defined in the input file `-d data_file`. Column 3 represents the prior probability that we learned using the logistic model considering the annotations and the distance. Column 4 is the Posterior Inclusion Probability (PIP). Finally, column 5 represents the false discovery probability of the gene (on single value per gene, same as in `-qtl` output). 
