### PR TITLE
Fix compilation issues where sqrt wasn't declared

### DIFF
--- a/dap_src/parser.cc
+++ b/dap_src/parser.cc
@@ -5,6 +5,7 @@ using namespace std;
 #include <string>
 #include <sstream>
 #include <fstream>
+#include <cmath>
 #include <gsl/gsl_linalg.h>
 #include <gsl/gsl_blas.h>
 

--- a/dap_src/parser.h
+++ b/dap_src/parser.h
@@ -3,6 +3,7 @@
 #include <sstream>
 #include <map>
 #include <vector>
+#include <cmath>
 #include <string.h>
 #include <gsl/gsl_matrix.h>
 


### PR DESCRIPTION
`sqrt` is part of cmath, not standard C++ library. I've added an include statement to import cmath to use `sqrt` and avoid compilation errors